### PR TITLE
19 and 29 override default fonts

### DIFF
--- a/src/components/TldrawApp.tsx
+++ b/src/components/TldrawApp.tsx
@@ -6,6 +6,7 @@ import {
 	DefaultMainMenuContent,
 	TLComponents,
 	Tldraw,
+	TldrawProps,
 	TldrawUiMenuItem,
 	TldrawUiMenuSubmenu,
 	createTLStore,
@@ -65,6 +66,7 @@ type TldrawAppOptions = {
 	 * Whether or not to initially zoom to the bounds of the document when the component is mounted.
 	 */
 	zoomToBounds?: boolean,
+	defaultFontOverrides?: NonNullable<TldrawProps['assetUrls']>['fonts']
 };
 
 export type TldrawAppProps = {
@@ -97,7 +99,8 @@ function LocalFileMenu() {
 const TldrawApp = ({ settings, initialData, setFileData, options: {
 	autoFocus = true,
 	isReadonly = false,
-	zoomToBounds = false
+	zoomToBounds = false,
+	defaultFontOverrides
 } }: TldrawAppProps) => {
 	const saveDelayInMs = safeSecondsToMs(settings.saveFileDelay);
 
@@ -132,6 +135,9 @@ const TldrawApp = ({ settings, initialData, setFileData, options: {
 			onTouchStart={(e) => e.stopPropagation()}
 		>
 			<Tldraw
+				assetUrls={{
+					fonts: defaultFontOverrides
+				}}
 				overrides={uiOverrides}
 				store={store}
 				components={components}

--- a/src/components/TldrawApp.tsx
+++ b/src/components/TldrawApp.tsx
@@ -58,12 +58,20 @@ export const uiOverrides: TLUiOverrides = {
 	// },
 };
 
+type TldrawAppOptions = {
+	isReadonly?: boolean,
+	autoFocus?: boolean,
+	/**
+	 * Whether or not to initially zoom to the bounds of the document when the component is mounted.
+	 */
+	zoomToBounds?: boolean,
+};
+
 export type TldrawAppProps = {
 	settings: TldrawPluginSettings;
 	initialData: SerializedStore<TLRecord>;
 	setFileData: (data: SerializedStore<TLRecord>) => void;
-	isReadonly?: boolean,
-	autoFocus?: boolean
+	options: TldrawAppOptions
 };
 
 // https://github.com/tldraw/tldraw/blob/58890dcfce698802f745253ca42584731d126cc3/apps/examples/src/examples/custom-main-menu/CustomMainMenuExample.tsx
@@ -86,7 +94,11 @@ function LocalFileMenu() {
 	);
 }
 
-const TldrawApp = ({ settings, initialData, setFileData, isReadonly, autoFocus }: TldrawAppProps) => {
+const TldrawApp = ({ settings, initialData, setFileData, options: {
+	autoFocus = true,
+	isReadonly = false,
+	zoomToBounds = false
+} }: TldrawAppProps) => {
 	const saveDelayInMs = safeSecondsToMs(settings.saveFileDelay);
 
 	const [store] = useState(() => createTLStore({
@@ -124,7 +136,7 @@ const TldrawApp = ({ settings, initialData, setFileData, isReadonly, autoFocus }
 				store={store}
 				components={components}
 				// Set this flag to false when a tldraw document is embed into markdown to prevent it from gaining focus when it is loaded.
-				autoFocus={autoFocus ?? true}
+				autoFocus={autoFocus}
 				onMount={(editor) => {
 					const {
 						themeMode,
@@ -150,11 +162,15 @@ const TldrawApp = ({ settings, initialData, setFileData, isReadonly, autoFocus }
 					});
 
 					editor.updateInstanceState({
-						isReadonly: isReadonly ?? false,
+						isReadonly: isReadonly,
 						isGridMode: gridMode,
 						isDebugMode: debugMode,
 						isFocusMode: focusMode,
 					});
+
+					if (zoomToBounds) {
+						editor.zoomToBounds(editor.getCurrentPageBounds()!, { duration: 0 });
+					}
 				}}
 			/>
 		</div>
@@ -166,10 +182,7 @@ export const createRootAndRenderTldrawApp = (
 	initialData: SerializedStore<TLRecord>,
 	setFileData: (data: SerializedStore<TLRecord>) => void,
 	settings: TldrawPluginSettings,
-	options?: {
-		isReadonly?: boolean,
-		autoFocus?: boolean
-	}
+	options: TldrawAppOptions = {}
 ) => {
 	const root = createRoot(node);
 
@@ -178,8 +191,7 @@ export const createRootAndRenderTldrawApp = (
 			setFileData={setFileData}
 			initialData={initialData}
 			settings={settings}
-			isReadonly={options?.isReadonly}
-			autoFocus={options?.autoFocus}
+			options={options}
 		/>
 	);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,8 @@ import { around } from "monkey-around";
 import { TldrawReadonly } from "./obsidian/TldrawReadonly";
 import { pluginBuild } from "./utils/decorators/plugin";
 import { markdownPostProcessor } from "./obsidian/plugin/markdown-post-processor";
+// import { getFontAssets } from "./utils/fonts";
+import { processFontOverrides } from "./obsidian/plugin/settings";
 
 @pluginBuild
 export default class TldrawPlugin extends Plugin {
@@ -482,5 +484,10 @@ export default class TldrawPlugin extends Plugin {
 
 	async saveSettings() {
 		await this.saveData(this.settings);
+	}
+	getFontOverrides() {
+		return processFontOverrides(this.settings.fonts?.overrides, (font) => {
+			return this.app.vault.adapter.getResourcePath(font).split('?')[0]
+		});
 	}
 }

--- a/src/obsidian/TldrawReadonly.ts
+++ b/src/obsidian/TldrawReadonly.ts
@@ -1,12 +1,12 @@
 import { FileView, TFile, WorkspaceLeaf } from "obsidian";
 import { Root } from "react-dom/client";
-import { createRootAndRenderTldrawApp } from "src/components/TldrawApp";
+import {  TldrawAppProps } from "src/components/TldrawApp";
 import TldrawPlugin from "src/main";
 import { TLDRAW_ICON_NAME, VIEW_TYPE_TLDRAW, VIEW_TYPE_TLDRAW_READ_ONLY } from "src/utils/constants";
 import { parseTLData } from "src/utils/parse";
 import { TldrawLoadableMixin } from "./TldrawMixins";
-import { TLData } from "src/utils/document";
-import { logFn } from "src/utils/logging";
+import { logClass } from "src/utils/logging";
+import { SerializedStore, TLRecord } from "@tldraw/tldraw";
 
 export class TldrawReadonly extends TldrawLoadableMixin(FileView) {
     plugin: TldrawPlugin;
@@ -40,17 +40,14 @@ export class TldrawReadonly extends TldrawLoadableMixin(FileView) {
         await this.setTlData(parsedData);
     }
 
-    protected createReactRoot(entryPoint: Element, tldata: TLData): Root {
-        return createRootAndRenderTldrawApp(
-            entryPoint,
-            tldata.raw,
-            function readonlyIgnoreSave(_) {
-                logFn(readonlyIgnoreSave, 'Ignore saving file due to read only mode.');
-            },
-            this.plugin.settings,
-            {
-                isReadonly: true
-            }
-        );
+    protected setFileData(data: SerializedStore<TLRecord>): void {
+        logClass(TldrawReadonly, this.setFileData, 'Ignore saving file due to read only mode.');
+    }
+
+    protected override getTldrawOptions(): TldrawAppProps['options'] {
+        return {
+            ...super.getTldrawOptions(),
+            isReadonly: true,
+        }
     }
 }

--- a/src/obsidian/TldrawSettingsTab.ts
+++ b/src/obsidian/TldrawSettingsTab.ts
@@ -333,14 +333,11 @@ export class TldrawSettingsTab extends PluginSettingTab {
 					})
 			}
 
-			const drawFontSetting = newFontOverrideSetting({
+			newFontOverrideSetting({
 				name: 'Draw (handwriting) font',
 				font: 'draw',
 				appearsAs: 'draw',
 			});
-
-			console.log(drawFontSetting.settingEl)
-
 			newFontOverrideSetting({
 				name: 'Sans-serif font',
 				font: 'sansSerif',

--- a/src/obsidian/TldrawView.ts
+++ b/src/obsidian/TldrawView.ts
@@ -5,7 +5,6 @@ import {
 	TLDATA_DELIMITER_START,
 	VIEW_TYPE_TLDRAW,
 } from "../utils/constants";
-import { createRootAndRenderTldrawApp } from "../components/TldrawApp";
 import TldrawPlugin from "../main";
 import { replaceBetweenKeywords } from "src/utils/utils";
 import { SerializedStore } from "@tldraw/store";
@@ -45,15 +44,6 @@ export class TldrawView extends TldrawLoadableMixin(TextFileView) {
 		this.setTlData(initialData);
 	}
 
-	protected createReactRoot(entryPoint: HTMLElement, tldata: TLData): Root {
-		return createRootAndRenderTldrawApp(
-			entryPoint,
-			tldata.raw,
-			this.setFileData,
-			this.plugin.settings
-		);
-	}
-
 	clear(): void { }
 
 	getTldrawData = (rawFileData?: string): TLData => {
@@ -62,7 +52,7 @@ export class TldrawView extends TldrawLoadableMixin(TextFileView) {
 		return parseTLData(this.plugin.manifest.version, rawFileData);
 	};
 
-	setFileData = async (data: SerializedStore<TLRecord>) => {
+	override setFileData = async (data: SerializedStore<TLRecord>) => {
 		const tldrawData = getTLDataTemplate(
 			this.plugin.manifest.version,
 			data

--- a/src/obsidian/plugin/markdown-post-processor.ts
+++ b/src/obsidian/plugin/markdown-post-processor.ts
@@ -152,7 +152,8 @@ export async function markdownPostProcessor(plugin: TldrawPlugin, element: HTMLE
             plugin.settings,
             {
                 isReadonly: true,
-                autoFocus: false
+                autoFocus: false,
+                zoomToBounds: true,
             }
         );
 

--- a/src/obsidian/plugin/markdown-post-processor.ts
+++ b/src/obsidian/plugin/markdown-post-processor.ts
@@ -154,6 +154,7 @@ export async function markdownPostProcessor(plugin: TldrawPlugin, element: HTMLE
                 isReadonly: true,
                 autoFocus: false,
                 zoomToBounds: true,
+                defaultFontOverrides: plugin.getFontOverrides(),
             }
         );
 

--- a/src/obsidian/plugin/settings.ts
+++ b/src/obsidian/plugin/settings.ts
@@ -1,0 +1,76 @@
+import { TldrawAppProps } from "src/components/TldrawApp";
+import { TldrawPluginSettings } from "../TldrawSettingsTab";
+
+type FontOverridesSettings = NonNullable<TldrawPluginSettings['fonts']>['overrides'];
+
+export function processFontOverrides(
+    overrides: FontOverridesSettings,
+    getResourcePath: (font: string) => string
+): TldrawAppProps['options']['defaultFontOverrides'] {
+    if (overrides === undefined) return undefined;
+    const { draw, monospace, sansSerif, serif } = overrides;
+
+    const processed: NonNullable<FontOverridesSettings> = {};
+
+    if (draw !== undefined) {
+        processed.draw = getResourcePath(draw);
+    }
+
+    if (monospace !== undefined) {
+        processed.monospace = getResourcePath(monospace);
+    }
+
+    if (sansSerif !== undefined) {
+        processed.sansSerif = getResourcePath(sansSerif);
+    }
+
+    if (serif !== undefined) {
+        processed.serif = getResourcePath(serif);
+    }
+
+    return processed;
+}
+
+
+function addIfDefined<T extends Record<string, unknown>>(object: T, key: keyof T, value: T[keyof T] | undefined) {
+    if (value !== undefined) {
+        object[key] = value;
+    }
+}
+
+/**
+ * If a value is null or length of 0, then it represents "update to default value".
+ */
+type FontOverridesSettingsUpdate = {
+    [k in keyof NonNullable<FontOverridesSettings>]: NonNullable<FontOverridesSettings>[k] | null
+}
+
+function getFontOverrideOrUndefinedForDefault(
+    font: keyof NonNullable<FontOverridesSettings>,
+    original: FontOverridesSettings,
+    updates: FontOverridesSettingsUpdate,
+) {
+    return updates[font] === null
+        ? undefined
+        : updates[font] ?? original?.[font];
+}
+
+export function updateFontOverrides(
+    original: FontOverridesSettings,
+    updates: FontOverridesSettingsUpdate
+): FontOverridesSettings {
+    const object: NonNullable<FontOverridesSettings> = {};
+    addIfDefined(object,
+        'draw', getFontOverrideOrUndefinedForDefault('draw', original, updates),
+    )
+    addIfDefined(object,
+        'sansSerif', getFontOverrideOrUndefinedForDefault('sansSerif', original, updates),
+    )
+    addIfDefined(object,
+        'serif', getFontOverrideOrUndefinedForDefault('serif', original, updates),
+    )
+    addIfDefined(object,
+        'monospace', getFontOverrideOrUndefinedForDefault('monospace', original, updates),
+    )
+    return object;
+}

--- a/src/obsidian/settings/FontSearchModal.ts
+++ b/src/obsidian/settings/FontSearchModal.ts
@@ -63,7 +63,6 @@ export class FontSearchModal extends SuggestModal<TFile | TFolder> {
             if (!(dir instanceof TFolder)) {
                 return res({ searchPath, results: [], })
             }
-            console.log('exact search', dir);
             return res({
                 searchPath,
                 results: filterSearchPath(dir, searchPath)
@@ -106,7 +105,6 @@ export class FontSearchModal extends SuggestModal<TFile | TFolder> {
 
             this.searchResolver = resolver;
             if (lastResolver) {
-                console.log('resolve last promise')
                 lastResolver(this.searchRes);
             }
             this.searchPath(query, resolver);
@@ -157,7 +155,6 @@ function filterSearchPath(tFolder: TFolder, searchPath: string) {
 
 function debounce<T extends [unknown, ...unknown[]]>(/** callback to debounce */ cb: (...args: T) => void, /** milliseconds */ wait: number) {
     let timeout: undefined | NodeJS.Timeout;
-    console.log('Debouncing with ms = ', wait)
     return function (...args: T) {
         clearTimeout(timeout);
         timeout = setTimeout(() => cb(...args), wait);

--- a/src/obsidian/settings/FontSearchModal.ts
+++ b/src/obsidian/settings/FontSearchModal.ts
@@ -57,7 +57,6 @@ export class FontSearchModal extends SuggestModal<TFile | TFolder> {
             ? '/' : searchPathParsed.dir;
         const dir = this.app.vault.getAbstractFileByPath(searchDir);
 
-
         if (searchPath.endsWith('/')) {
             const dir = this.app.vault.getAbstractFileByPath(searchPath.slice(0, searchPath.length - 1));
             if (!(dir instanceof TFolder)) {
@@ -68,26 +67,12 @@ export class FontSearchModal extends SuggestModal<TFile | TFolder> {
                 results: filterSearchPath(dir, searchPath)
             })
         }
-
-        try {
-            const currentDir = dir === null || !(dir instanceof TFolder)
+        res({
+            searchPath,
+            results: !(dir instanceof TFolder)
                 ? []
-                : filterSearchPath(dir, searchPath);
-
-            const first = currentDir.at(0);
-            res({
-                searchPath,
-                results: (currentDir.length !== 1 || !(first instanceof TFolder)
-                    ? currentDir
-                    : (
-                        !first
-                            ? []
-                            : filterSearchPath(first, searchPath)
-                    )),
-            });
-        } finally {
-            this.searchResolver = undefined;
-        }
+                : filterSearchPath(dir, searchPath),
+        });
     }, 100);
 
     async changeInputValue(value: string) {
@@ -99,6 +84,7 @@ export class FontSearchModal extends SuggestModal<TFile | TFolder> {
         const lastResolver = this.searchResolver;
         return new Promise<(TFile | TFolder)[]>((res) => {
             const resolver: typeof this.searchResolver = (r) => {
+                this.searchResolver = undefined;
                 this.searchRes = r;
                 return res(r.results);
             }

--- a/src/obsidian/settings/FontSearchModal.ts
+++ b/src/obsidian/settings/FontSearchModal.ts
@@ -1,0 +1,165 @@
+import { SuggestModal, TFile, TFolder } from "obsidian";
+import * as path from "path";
+import TldrawPlugin from "src/main";
+
+const fontTypes = [
+    'otf',
+    'ttf',
+    'woff',
+    'woff2'
+] as const;
+
+export class FontSearchModal extends SuggestModal<TFile | TFolder> {
+    plugin: TldrawPlugin;
+
+    readonly initialValue?: string;
+    private readonly setFont: (font: string) => void;
+
+    /**
+     * This function is present at runtime in the web developer console in Obsidian, but not in the type definition for some reason.
+     */
+    declare updateSuggestions: () => void;
+
+    private searchRes: {
+        searchPath: string,
+        results: (TFolder | TFile)[],
+    } = {
+            searchPath: '',
+            results: [],
+        };
+
+    private searchResolver?: (res: typeof this.searchRes) => void;
+
+    constructor(plugin: TldrawPlugin, options: {
+        initialValue?: string,
+        setFont: (fontPath: string) => void
+    }) {
+        super(plugin.app);
+        this.plugin = plugin;
+        this.setFont = options.setFont;
+        this.initialValue = options.initialValue;
+    }
+
+    onOpen(): void {
+        super.onOpen();
+
+        if (this.initialValue) {
+            this.changeInputValue(this.initialValue)
+        }
+    }
+
+    /**
+     * Search a path for font assets
+     */
+    searchPath = debounce((searchPath: string, res: (result: typeof this.searchRes) => void) => {
+        const searchPathParsed = path.parse(searchPath);
+        const searchDir = searchPathParsed.dir.length === 0
+            ? '/' : searchPathParsed.dir;
+        const dir = this.app.vault.getAbstractFileByPath(searchDir);
+
+
+        if (searchPath.endsWith('/')) {
+            const dir = this.app.vault.getAbstractFileByPath(searchPath.slice(0, searchPath.length - 1));
+            if (!(dir instanceof TFolder)) {
+                return res({ searchPath, results: [], })
+            }
+            console.log('exact search', dir);
+            return res({
+                searchPath,
+                results: filterSearchPath(dir, searchPath)
+            })
+        }
+
+        try {
+            const currentDir = dir === null || !(dir instanceof TFolder)
+                ? []
+                : filterSearchPath(dir, searchPath);
+
+            const first = currentDir.at(0);
+            res({
+                searchPath,
+                results: (currentDir.length !== 1 || !(first instanceof TFolder)
+                    ? currentDir
+                    : (
+                        !first
+                            ? []
+                            : filterSearchPath(first, searchPath)
+                    )),
+            });
+        } finally {
+            this.searchResolver = undefined;
+        }
+    }, 100);
+
+    async changeInputValue(value: string) {
+        this.inputEl.value = value;
+        this.updateSuggestions();
+    }
+
+    getSuggestions(query: string): Promise<(TFile | TFolder)[]> {
+        const lastResolver = this.searchResolver;
+        return new Promise<(TFile | TFolder)[]>((res) => {
+            const resolver: typeof this.searchResolver = (r) => {
+                this.searchRes = r;
+                return res(r.results);
+            }
+
+            this.searchResolver = resolver;
+            if (lastResolver) {
+                console.log('resolve last promise')
+                lastResolver(this.searchRes);
+            }
+            this.searchPath(query, resolver);
+        });
+    }
+
+    renderSuggestion(file: TFile | TFolder, el: HTMLElement) {
+        const { searchPath } = this.searchRes;
+        const parsedSearchDir = path.parse(searchPath).dir;
+        const searchDir = parsedSearchDir.length === 0
+            ? searchPath : parsedSearchDir;
+        const text = searchPath.length === 0
+            ? `${file.path}${file instanceof TFolder ? '/' : ''}`
+            : `...${file.path.substring(searchDir.length)}${file instanceof TFolder ? '/' : ''}`;
+        el.createEl("div", { text });
+    }
+
+    onChooseSuggestion(value: TFile | TFolder, evt: MouseEvent | KeyboardEvent) {
+        this.setFont(value.path);
+        this.close();
+    }
+
+    selectSuggestion(value: TFile | TFolder, evt: MouseEvent | KeyboardEvent): void {
+        if (value instanceof TFile) {
+            this.onChooseSuggestion(value, evt);
+            return;
+        }
+
+        this.changeInputValue(`${value.path}/`);
+    }
+
+    onNoSuggestion(): void {
+        this.emptyStateText = `No folders or fonts at "${this.searchRes.searchPath}".`;
+        return super.onNoSuggestion();
+    }
+}
+
+function filterSearchPath(tFolder: TFolder, searchPath: string) {
+    return tFolder.children.map((e) => (
+        !(e instanceof TFolder) && !(e instanceof TFile)
+            ? undefined
+            : e instanceof TFolder ? e : (
+                fontTypes as readonly string[]
+            ).includes(e.extension) ? e : undefined
+    )).filter((e) => e !== undefined)
+        .filter((e) => e.path.startsWith(searchPath));
+}
+
+function debounce<T extends [unknown, ...unknown[]]>(/** callback to debounce */ cb: (...args: T) => void, /** milliseconds */ wait: number) {
+    let timeout: undefined | NodeJS.Timeout;
+    console.log('Debouncing with ms = ', wait)
+    return function (...args: T) {
+        clearTimeout(timeout);
+        timeout = setTimeout(() => cb(...args), wait);
+    };
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,0 +1,46 @@
+import {
+	TLUiActionItem,
+	TLDRAW_FILE_EXTENSION,
+	serializeTldrawJsonBlob,
+	Editor,
+} from "@tldraw/tldraw";
+
+export const SAVE_FILE_COPY_ACTION = "save-file-copy";
+
+// https://github.com/tldraw/tldraw/blob/58890dcfce698802f745253ca42584731d126cc3/packages/tldraw/src/lib/utils/export/exportAs.ts#L57
+export const downloadFile = (file: File) => {
+	const link = document.createElement("a");
+	const url = URL.createObjectURL(file);
+	link.href = url;
+	link.download = file.name;
+	link.click();
+	URL.revokeObjectURL(url);
+};
+
+// https://github.com/tldraw/tldraw/blob/58890dcfce698802f745253ca42584731d126cc3/apps/dotcom/src/utils/useFileSystem.tsx#L111
+export function getSaveFileCopyAction(
+	editor: Editor,
+	defaultDocumentName: string
+): TLUiActionItem {
+	return {
+		id: SAVE_FILE_COPY_ACTION,
+		label: "action.save-copy",
+		readonlyOk: true,
+		kbd: "$s",
+		async onSelect() {
+			const defaultName = `${defaultDocumentName}${TLDRAW_FILE_EXTENSION}`;
+
+			const blobToSave = await serializeTldrawJsonBlob(editor.store);
+
+			try {
+				const file = new File([blobToSave], defaultName, {
+					type: blobToSave.type,
+				});
+				downloadFile(file);
+			} catch (e) {
+				// user cancelled
+				return;
+			}
+		},
+	};
+}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -26,7 +26,6 @@ export function getSaveFileCopyAction(
 		id: SAVE_FILE_COPY_ACTION,
 		label: "action.save-copy",
 		readonlyOk: true,
-		kbd: "$s",
 		async onSelect() {
 			const defaultName = `${defaultDocumentName}${TLDRAW_FILE_EXTENSION}`;
 

--- a/src/utils/fonts.ts
+++ b/src/utils/fonts.ts
@@ -1,0 +1,58 @@
+import { TFile, TFolder } from "obsidian";
+
+type FontAsset = [type: 'license' | 'font', file: TFile];
+
+function fontAssetMatcher(file: TFile): undefined | FontAsset {
+    const licenseMatch = /license/i;
+    if (licenseMatch.test(file.name)) {
+        return ['license', file];
+    }
+
+    if (![
+        'otf',
+        'ttf',
+        'woff',
+        'woff2'
+    ].includes(file.extension)) return;
+
+    return ['font', file];
+}
+
+function fontAssetMapper(files: TFile[]) {
+    return files.filter((e) => e instanceof TFile)
+        .map((e) => fontAssetMatcher(e))
+        .filter((e) => e !== undefined);
+}
+
+export function getFontAssets(tFolder: TFolder) {
+    // Expect the fonts to be in their own subdirectories for organization purposes.
+    const fontAssets = fontAssetMapper(tFolder.children.filter((e) => e instanceof TFile));
+
+    const dirs = tFolder.children.filter((e) => e instanceof TFolder);
+    const subDirsFonts: [dir: TFolder, assets: FontAsset[]][] = [];
+
+    for (const dir of dirs) {
+        const subDirFontAssets = fontAssetMapper(dir.children.filter((e) => e instanceof TFile));
+        if (subDirFontAssets.length === 0) continue;
+        subDirsFonts.push([dir, subDirFontAssets]);
+    }
+
+    return {
+        fontAssets,
+        searchDir: tFolder,
+        subDirs: subDirsFonts,
+        getAll() {
+            return [
+                ...this.fontAssets,
+                ...this.subDirs.reduce<FontAsset[]>((prev, e) => {
+                    prev.push(...e[1]);
+                    return prev;
+                }, [])
+            ]
+        },
+        getAllAssetType(type: FontAsset[0]) {
+            return this.getAll()
+                .filter((e) => e[0] === type).map((e) => e[1]);
+        },
+    };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
 		"target": "ES6",
 		"allowJs": true,
 		"noImplicitAny": true,
+		"noImplicitThis": true,
 		"moduleResolution": "node",
 		"importHelpers": true,
 		"isolatedModules": true,


### PR DESCRIPTION
Original issues: #19, #29

Includes the changes from #26, #30 

Instructions to install the release here: https://github.com/jon-dez/tldraw-in-obsidian/releases/tag/issue-19-and-29--2

The video below shows how to use font files that are located in your vault to override the default fonts in tldraw.

https://github.com/user-attachments/assets/23475d47-e534-4701-bef4-d1afbb6c6f97

