### PR TITLE
Fix embed command ignoring defaultFolder destination setting

### DIFF
--- a/src/obsidian/plugin/file-destination.ts
+++ b/src/obsidian/plugin/file-destination.ts
@@ -38,10 +38,9 @@ export async function getTldrawFileDestination(
 	} = plugin.settings
 
 	const defaultRes = (() => {
-		if (attachTo || destinationMethod === 'attachments-folder') {
-			return getAttachmentsFolder(plugin.app, attachTo)
-		}
 		switch (destinationMethod) {
+			case 'attachments-folder':
+				return getAttachmentsFolder(plugin.app, attachTo)
 			case 'colocate':
 				return getColocationDestination(plugin)
 			case 'default-folder':


### PR DESCRIPTION
## Summary

> 🚨NOTE: This PR (including code) was created with Claude Code.

- When creating a new drawing via the `/` embed command, `attachTo` is always set to the current file. The condition `(attachTo || destinationMethod === 'attachments-folder')` in `getTldrawFileDestination` therefore always short-circuits to `true`, causing the file to be saved to Obsidian's core `attachmentFolderPath` regardless of the plugin's `destinationMethod` setting.
- Users who set `destinationMethod` to `"default-folder"` (e.g. `"Drawings"`) have their preference silently ignored for embed commands — files end up in the vault's attachment folder instead.
- The fix replaces the short-circuiting `if` with a direct `switch` on `destinationMethod`, so `attachTo` no longer overrides the configured destination.

## Steps to reproduce

1. Set `destinationMethod` to `"default-folder"` and `defaultFolder` to any folder (e.g. `"Drawings"`)
2. Set `confirmDestination` to `false`
3. Set Obsidian's core `attachmentFolderPath` to a different folder (e.g. `"Attachments"`)
4. Open a note and use the `/` slash command to embed a new tldraw drawing
5. **Expected:** file is created in `"Drawings"`
6. **Actual:** file is created in `"Attachments"`

Note: when `confirmDestination` is `true`, the confirmation modal works correctly because it builds the destination list independently without the `attachTo` short-circuit.

## Test plan

- [ ] Verify embed command respects `defaultFolder` when `destinationMethod` is `"default-folder"` and `confirmDestination` is `false`
- [ ] Verify embed command still uses Obsidian's attachment folder when `destinationMethod` is `"attachments-folder"`
- [ ] Verify colocate mode still works for embed commands
- [ ] Verify non-embed "create new drawing" commands still work correctly
- [ ] Verify `confirmDestination: true` still works as before