### PR TITLE
Scope the global button:not(.clickable-icon) color override to .tldraw-view-root

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -24,7 +24,9 @@
 	visibility: hidden;
 }
 
-button:not(.clickable-icon) {
+/* Scoped to .tldraw-view-root so it only overrides Obsidian's button color inside
+   tldraw, instead of leaking to every button in the app (e.g. Settings, Notices). #203 */
+.tldraw-view-root button:not(.clickable-icon) {
 	color: currentColor;
 }
 


### PR DESCRIPTION
Fixes #203.

`src/styles.css` ships an **unscoped** global rule:

```css
button:not(.clickable-icon) {
  color: currentColor;
}
```

Because it isn't scoped to a tldraw container, it applies to **every** `<button>` in Obsidian, overriding Obsidian's default `button:not(.clickable-icon){color:var(--text-color)}` app-wide. `currentColor` then resolves to whatever text color the surrounding context inherits, so buttons outside tldraw lose contrast wherever that differs from their background — e.g. the Settings "Check for Updates" button in #203, and action buttons inside a `Notice` (white-on-white).

This scopes the rule to `.tldraw-view-root`, matching the convention already used right below it for the `.tldraw-view-root .tlui-button` override. Specificity becomes (0,2,1), so it still wins over Obsidian's (0,1,1) inside the tldraw view, while no longer leaking to the rest of the app.

Note: this assumes all tldraw buttons live under `.tldraw-view-root` (true for the in-view UI; the existing `.tldraw-view-root .tlui-button` override relies on the same assumption). If any tldraw UI is portaled outside that root, `.tl-container` would be the alternative scope.
