### PR TITLE
Acknowledge .tldraw files from tldraw offline

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -16,6 +16,7 @@ import { Root } from 'react-dom/client'
 import { Editor, TLDRAW_FILE_EXTENSION, TLStore } from 'tldraw'
 import { createReactStatusBarViewMode } from './components/StatusBarViewMode'
 import createMain from './components/plugin/TldrawInObsidian'
+import { TldrawOfflineFileView } from './obsidian/TldrawOfflineFileView'
 import { ReadonlyTldrawView } from './obsidian/TldrawReadonlyView'
 import {
 	DEFAULT_SETTINGS,
@@ -45,6 +46,7 @@ import {
 	TLDRAW_ICON_NAME,
 	VIEW_TYPE_MARKDOWN,
 	VIEW_TYPE_TLDRAW,
+	VIEW_TYPE_TLDRAW_OFFLINE,
 	VIEW_TYPE_TLDRAW_READ_ONLY,
 	ViewType,
 } from './utils/constants'
@@ -103,6 +105,8 @@ export default class TldrawPlugin extends Plugin {
 		this.registerView(VIEW_TYPE_TLDRAW, (leaf) => new EditableTldrawView(leaf, this))
 
 		this.registerView(VIEW_TYPE_TLDRAW_READ_ONLY, (leaf) => new ReadonlyTldrawView(leaf, this))
+
+		this.registerView(VIEW_TYPE_TLDRAW_OFFLINE, (leaf) => new TldrawOfflineFileView(leaf))
 
 		// settings:
 		await this.settingsManager.loadSettings()
@@ -164,6 +168,14 @@ export default class TldrawPlugin extends Plugin {
 		this.register(() => this.app.embedRegistry.unregisterExtension('tldr'))
 
 		this.registerExtensions(['tldr'], VIEW_TYPE_TLDRAW)
+
+		try {
+			this.registerExtensions(['tldraw'], VIEW_TYPE_TLDRAW_OFFLINE)
+		} catch (e) {
+			// Obsidian throws if another plugin already owns the extension. Explaining that we can't
+			// open these files isn't worth taking the file type away from a plugin that can.
+			console.error(e)
+		}
 
 		const unmount = createMain(this, this.app.dom.statusBarEl)
 		this.register(() => {

--- a/src/obsidian/TldrawOfflineFileView.ts
+++ b/src/obsidian/TldrawOfflineFileView.ts
@@ -1,0 +1,41 @@
+import { FileView, WorkspaceLeaf } from 'obsidian'
+import { TLDRAW_ICON_NAME, VIEW_TYPE_TLDRAW_OFFLINE } from 'src/utils/constants'
+
+export const TLDRAW_OFFLINE_UNSUPPORTED_TITLE = 'Can’t open .tldraw files yet'
+export const TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE =
+	'We’re still working on support for files from tldraw offline.'
+
+/**
+ * Shown when a `.tldraw` file is opened. tldraw offline saves documents as an archive holding a
+ * SQLite database rather than the JSON a `.tldr` file holds, so we can't render one. We claim the
+ * extension anyway so that opening the file explains that, rather than leaving the user on
+ * Obsidian's generic "no view for this file type" screen.
+ *
+ * This extends `FileView` directly rather than `BaseTldrawFileView`, which reads the file as text
+ * and parses it as JSON — on an archive that only produces an opaque parse error.
+ */
+export class TldrawOfflineFileView extends FileView {
+	constructor(leaf: WorkspaceLeaf) {
+		super(leaf)
+		this.navigation = true
+	}
+
+	override getViewType() {
+		return VIEW_TYPE_TLDRAW_OFFLINE
+	}
+
+	override getIcon() {
+		return TLDRAW_ICON_NAME
+	}
+
+	override getDisplayText() {
+		return this.file ? this.file.basename : 'NO_FILE'
+	}
+
+	override async onOpen() {
+		this.contentEl.empty()
+		const container = this.contentEl.createDiv({ cls: 'ptl-offline-unsupported' })
+		container.createEl('h3', { text: TLDRAW_OFFLINE_UNSUPPORTED_TITLE })
+		container.createEl('p', { text: TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE })
+	}
+}

--- a/src/obsidian/TldrawOfflineFileView.ts
+++ b/src/obsidian/TldrawOfflineFileView.ts
@@ -1,6 +1,10 @@
 import { FileView, Menu, WorkspaceLeaf } from 'obsidian'
 import {
 	TLDRAW_ICON_NAME,
+	TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER,
+	TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE,
+	TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
+	TLDRAW_OFFLINE_EXPORT_URL,
 	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
 	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
 	VIEW_TYPE_TLDRAW_OFFLINE,
@@ -64,6 +68,14 @@ export class TldrawOfflineFileView extends FileView {
 		const container = this.contentEl.createDiv({ cls: 'ptl-offline-unsupported' })
 		container.createEl('h3', { text: TLDRAW_OFFLINE_UNSUPPORTED_TITLE })
 		container.createEl('p', { text: TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE })
+
+		const prompt = container.createEl('p')
+		prompt.appendText(TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE)
+		prompt.createEl('a', {
+			text: TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
+			href: TLDRAW_OFFLINE_EXPORT_URL,
+		})
+		prompt.appendText(TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER)
 	}
 
 	private openInDefaultApp() {

--- a/src/obsidian/TldrawOfflineFileView.ts
+++ b/src/obsidian/TldrawOfflineFileView.ts
@@ -1,14 +1,10 @@
 import { FileView, Menu, WorkspaceLeaf } from 'obsidian'
 import {
 	TLDRAW_ICON_NAME,
-	TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER,
-	TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE,
-	TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
-	TLDRAW_OFFLINE_EXPORT_URL,
-	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
 	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
 	VIEW_TYPE_TLDRAW_OFFLINE,
 } from 'src/utils/constants'
+import { appendTldrawOfflineMessage } from 'src/utils/tldraw-offline-message'
 import { pluginMenuLabel } from './menu'
 
 const OPEN_IN_DEFAULT_APP = 'Open in default app'
@@ -67,15 +63,7 @@ export class TldrawOfflineFileView extends FileView {
 		this.contentEl.empty()
 		const container = this.contentEl.createDiv({ cls: 'ptl-offline-unsupported' })
 		container.createEl('h3', { text: TLDRAW_OFFLINE_UNSUPPORTED_TITLE })
-		container.createEl('p', { text: TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE })
-
-		const prompt = container.createEl('p')
-		prompt.appendText(TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE)
-		prompt.createEl('a', {
-			text: TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
-			href: TLDRAW_OFFLINE_EXPORT_URL,
-		})
-		prompt.appendText(TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER)
+		appendTldrawOfflineMessage(container)
 	}
 
 	private openInDefaultApp() {

--- a/src/obsidian/TldrawOfflineFileView.ts
+++ b/src/obsidian/TldrawOfflineFileView.ts
@@ -1,15 +1,22 @@
-import { FileView, WorkspaceLeaf } from 'obsidian'
-import { TLDRAW_ICON_NAME, VIEW_TYPE_TLDRAW_OFFLINE } from 'src/utils/constants'
+import { FileView, Menu, WorkspaceLeaf } from 'obsidian'
+import {
+	TLDRAW_ICON_NAME,
+	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
+	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
+	VIEW_TYPE_TLDRAW_OFFLINE,
+} from 'src/utils/constants'
+import { pluginMenuLabel } from './menu'
 
-export const TLDRAW_OFFLINE_UNSUPPORTED_TITLE = 'Can’t open .tldraw files yet'
-export const TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE =
-	'We’re still working on support for files from tldraw offline.'
+const OPEN_IN_DEFAULT_APP = 'Open in default app'
 
 /**
  * Shown when a `.tldraw` file is opened. tldraw offline saves documents as an archive holding a
  * SQLite database rather than the JSON a `.tldr` file holds, so we can't render one. We claim the
  * extension anyway so that opening the file explains that, rather than leaving the user on
  * Obsidian's generic "no view for this file type" screen.
+ *
+ * Claiming the extension takes away Obsidian's own handling, so this offers "open in default app"
+ * to keep a route to whatever program can read the file.
  *
  * This extends `FileView` directly rather than `BaseTldrawFileView`, which reads the file as text
  * and parses it as JSON — on an archive that only produces an opaque parse error.
@@ -32,10 +39,35 @@ export class TldrawOfflineFileView extends FileView {
 		return this.file ? this.file.basename : 'NO_FILE'
 	}
 
+	override onload() {
+		super.onload()
+		this.addAction('external-link', OPEN_IN_DEFAULT_APP, () => this.openInDefaultApp())
+	}
+
+	override onPaneMenu(menu: Menu, source: 'more-options' | 'tab-header' | string): void {
+		super.onPaneMenu(menu, source)
+		if (!this.file) return
+
+		menu
+			.addItem((item) => pluginMenuLabel(item.setSection('tldraw')))
+			.addItem((item) =>
+				item
+					.setIcon('external-link')
+					.setSection('tldraw')
+					.setTitle(OPEN_IN_DEFAULT_APP)
+					.onClick(() => this.openInDefaultApp())
+			)
+	}
+
 	override async onOpen() {
 		this.contentEl.empty()
 		const container = this.contentEl.createDiv({ cls: 'ptl-offline-unsupported' })
 		container.createEl('h3', { text: TLDRAW_OFFLINE_UNSUPPORTED_TITLE })
 		container.createEl('p', { text: TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE })
+	}
+
+	private openInDefaultApp() {
+		if (!this.file) return
+		this.app.openWithDefaultApp(this.file.path)
 	}
 }

--- a/src/obsidian/plugin/commands.ts
+++ b/src/obsidian/plugin/commands.ts
@@ -28,9 +28,9 @@ async function createTldrawFile(
 			e instanceof Error
 				? e.message
 				: (() => {
-						console.error(e)
-						return 'An unknown error occurred while creating a new tldraw file.'
-					})()
+					console.error(e)
+					return 'An unknown error occurred while creating a new tldraw file.'
+				})()
 		)
 	}
 }

--- a/src/obsidian/plugin/commands.ts
+++ b/src/obsidian/plugin/commands.ts
@@ -28,9 +28,9 @@ async function createTldrawFile(
 			e instanceof Error
 				? e.message
 				: (() => {
-					console.error(e)
-					return 'An unknown error occurred while creating a new tldraw file.'
-				})()
+						console.error(e)
+						return 'An unknown error occurred while creating a new tldraw file.'
+					})()
 		)
 	}
 }
@@ -153,6 +153,7 @@ export function registerCommands(plugin: TldrawPlugin) {
 		name: 'Import file as new document and open in a new tab',
 		callback: async () => {
 			const tFile = await importTldrawFile(plugin)
+			if (!tFile) return
 			await plugin.openTldrFile(tFile, 'new-tab')
 		},
 	})
@@ -169,6 +170,7 @@ export function registerCommands(plugin: TldrawPlugin) {
 			const from = editor.getCursor('from')
 			const to = editor.getCursor('to')
 			const tFile = await importTldrawFile(plugin, file)
+			if (!tFile) return
 			editorInsert(new TldrawDocument(plugin, tFile), editor, from, to)
 		},
 	})

--- a/src/styles.css
+++ b/src/styles.css
@@ -548,3 +548,23 @@ div[data-type='tldraw-read-only'] .view-content.tldraw-view-content {
 .ptl-document-messages-actions button.mod-cta {
 	margin: 0;
 }
+
+.ptl-offline-unsupported {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--size-4-1);
+	height: 100%;
+	padding: var(--size-4-4);
+	text-align: center;
+}
+
+.ptl-offline-unsupported h3 {
+	margin: 0;
+}
+
+.ptl-offline-unsupported p {
+	margin: 0;
+	color: var(--text-muted);
+}

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -25,6 +25,9 @@ export const FILE_EXTENSION = '.md'
  * and its assets, not the JSON a `.tldr` file holds, so none of our parsing can read one.
  */
 export const TLDRAW_OFFLINE_FILE_EXTENSION = '.tldraw'
+export const TLDRAW_OFFLINE_UNSUPPORTED_TITLE = 'Can’t open .tldraw files yet'
+export const TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE =
+	'We’re still working on support for files from tldraw offline.'
 export const FRONTMATTER_KEY = 'tldraw-file'
 export const TLDATA_DELIMITER_START = '!!!_START_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'
 export const TLDATA_DELIMITER_END = '!!!_END_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -6,6 +6,11 @@ export type ViewType = (typeof VIEW_TYPES)[number]
 export const VIEW_TYPE_TLDRAW = 'tldraw-view' // custom view type
 
 export const VIEW_TYPE_TLDRAW_READ_ONLY = 'tldraw-read-only' // custom view type
+/**
+ * For `.tldraw` ending files. Deliberately left out of {@link VIEW_TYPES}, since it isn't a mode
+ * the user can switch a document into — it only exists to explain why we can't open the file.
+ */
+export const VIEW_TYPE_TLDRAW_OFFLINE = 'tldraw-offline' // custom view type
 export const VIEW_TYPE_MARKDOWN = 'markdown' // NOT ACTUALLY A CUSTOM VIEW TYPE, its built in from obsidian
 export const VIEW_TYPES = [
 	VIEW_TYPE_MARKDOWN,
@@ -15,6 +20,11 @@ export const VIEW_TYPES = [
 export const PANE_TARGETS = ['new-window', 'new-tab', 'current-tab', 'split-tab'] as const
 
 export const FILE_EXTENSION = '.md'
+/**
+ * The extension used by tldraw offline. A `.tldraw` file is an archive holding a SQLite database
+ * and its assets, not the JSON a `.tldr` file holds, so none of our parsing can read one.
+ */
+export const TLDRAW_OFFLINE_FILE_EXTENSION = '.tldraw'
 export const FRONTMATTER_KEY = 'tldraw-file'
 export const TLDATA_DELIMITER_START = '!!!_START_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'
 export const TLDATA_DELIMITER_END = '!!!_END_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -26,14 +26,6 @@ export const FILE_EXTENSION = '.md'
  */
 export const TLDRAW_OFFLINE_FILE_EXTENSION = '.tldraw'
 export const TLDRAW_OFFLINE_UNSUPPORTED_TITLE = 'Can’t open .tldraw files yet'
-export const TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE =
-	'We’re working on support for files from tldraw offline.'
-export const TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE = 'For now, you can '
-export const TLDRAW_OFFLINE_EXPORT_PROMPT_LINK = 'export as a .tldr file'
-export const TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER = ' to use it here.'
-/** Anchors the "Export as .tldr" section of the tldraw offline user manual. */
-export const TLDRAW_OFFLINE_EXPORT_URL =
-	'https://tldraw.notion.site/User-manual-tldraw-offline-39a3e4c324c080e7b2eacc5afd078e85#3aa3e4c324c080669967e2cc3ae2c789'
 export const FRONTMATTER_KEY = 'tldraw-file'
 export const TLDATA_DELIMITER_START = '!!!_START_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'
 export const TLDATA_DELIMITER_END = '!!!_END_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -27,7 +27,13 @@ export const FILE_EXTENSION = '.md'
 export const TLDRAW_OFFLINE_FILE_EXTENSION = '.tldraw'
 export const TLDRAW_OFFLINE_UNSUPPORTED_TITLE = 'Can’t open .tldraw files yet'
 export const TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE =
-	'We’re still working on support for files from tldraw offline.'
+	'We’re working on support for files from tldraw offline.'
+export const TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE = 'For now, you can '
+export const TLDRAW_OFFLINE_EXPORT_PROMPT_LINK = 'export as a .tldr file'
+export const TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER = ' to use it here.'
+/** Anchors the "Export as .tldr" section of the tldraw offline user manual. */
+export const TLDRAW_OFFLINE_EXPORT_URL =
+	'https://tldraw.notion.site/User-manual-tldraw-offline-39a3e4c324c080e7b2eacc5afd078e85#3aa3e4c324c080669967e2cc3ae2c789'
 export const FRONTMATTER_KEY = 'tldraw-file'
 export const TLDATA_DELIMITER_START = '!!!_START_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'
 export const TLDATA_DELIMITER_END = '!!!_END_OF_TLDRAW_DATA__DO_NOT_CHANGE_THIS_PHRASE_!!!'

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -8,16 +8,9 @@ import {
 	serializeTldrawJsonBlob,
 	useDefaultHelpers,
 } from 'tldraw'
-import {
-	TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER,
-	TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE,
-	TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
-	TLDRAW_OFFLINE_EXPORT_URL,
-	TLDRAW_OFFLINE_FILE_EXTENSION,
-	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
-	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
-} from './constants'
+import { TLDRAW_OFFLINE_FILE_EXTENSION, TLDRAW_OFFLINE_UNSUPPORTED_TITLE } from './constants'
 import { migrateTldrawFileDataIfNecessary } from './migrate/tl-data-to-tlstore'
+import { appendTldrawOfflineMessage } from './tldraw-offline-message'
 // import { shouldOverrideDocument } from "src/components/file-menu/shouldOverrideDocument";
 
 export const SAVE_FILE_COPY_ACTION = 'save-file-copy'
@@ -142,18 +135,10 @@ export async function importTldrawFile(
 		// Case-insensitive: file dialogs on macOS and Windows match their filters that way, so a
 		// `.TLDRAW` file is selectable and would otherwise fall through to the JSON parser.
 		if (file.name.toLowerCase().endsWith(TLDRAW_OFFLINE_FILE_EXTENSION)) {
-			// A fragment rather than a string so the notice can carry the link to the manual.
+			// A fragment rather than a string, so the notice can carry the links.
 			const notice = document.createDocumentFragment()
 			notice.createEl('strong', { text: TLDRAW_OFFLINE_UNSUPPORTED_TITLE })
-			notice.createEl('br')
-			notice.appendText(
-				`${TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE} ${TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE}`
-			)
-			notice.createEl('a', {
-				text: TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
-				href: TLDRAW_OFFLINE_EXPORT_URL,
-			})
-			notice.appendText(TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER)
+			appendTldrawOfflineMessage(notice)
 			new Notice(notice)
 			return undefined
 		}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,9 +1,5 @@
 import { Notice, Platform, TFile } from 'obsidian'
 import TldrawPlugin from 'src/main'
-import {
-	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
-	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
-} from 'src/obsidian/TldrawOfflineFileView'
 import { showSaveFileModal } from 'src/obsidian/modal/save-file-modal'
 import {
 	Editor,
@@ -12,7 +8,11 @@ import {
 	serializeTldrawJsonBlob,
 	useDefaultHelpers,
 } from 'tldraw'
-import { TLDRAW_OFFLINE_FILE_EXTENSION } from './constants'
+import {
+	TLDRAW_OFFLINE_FILE_EXTENSION,
+	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
+	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
+} from './constants'
 import { migrateTldrawFileDataIfNecessary } from './migrate/tl-data-to-tlstore'
 // import { shouldOverrideDocument } from "src/components/file-menu/shouldOverrideDocument";
 
@@ -135,7 +135,9 @@ export async function importTldrawFile(
 			excludeAcceptAllOption: true,
 		})
 
-		if (file.name.endsWith(TLDRAW_OFFLINE_FILE_EXTENSION)) {
+		// Case-insensitive: file dialogs on macOS and Windows match their filters that way, so a
+		// `.TLDRAW` file is selectable and would otherwise fall through to the JSON parser.
+		if (file.name.toLowerCase().endsWith(TLDRAW_OFFLINE_FILE_EXTENSION)) {
 			new Notice(`${TLDRAW_OFFLINE_UNSUPPORTED_TITLE}. ${TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE}`)
 			return undefined
 		}

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -9,6 +9,10 @@ import {
 	useDefaultHelpers,
 } from 'tldraw'
 import {
+	TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER,
+	TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE,
+	TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
+	TLDRAW_OFFLINE_EXPORT_URL,
 	TLDRAW_OFFLINE_FILE_EXTENSION,
 	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
 	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
@@ -138,7 +142,19 @@ export async function importTldrawFile(
 		// Case-insensitive: file dialogs on macOS and Windows match their filters that way, so a
 		// `.TLDRAW` file is selectable and would otherwise fall through to the JSON parser.
 		if (file.name.toLowerCase().endsWith(TLDRAW_OFFLINE_FILE_EXTENSION)) {
-			new Notice(`${TLDRAW_OFFLINE_UNSUPPORTED_TITLE}. ${TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE}`)
+			// A fragment rather than a string so the notice can carry the link to the manual.
+			const notice = document.createDocumentFragment()
+			notice.createEl('strong', { text: TLDRAW_OFFLINE_UNSUPPORTED_TITLE })
+			notice.createEl('br')
+			notice.appendText(
+				`${TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE} ${TLDRAW_OFFLINE_EXPORT_PROMPT_BEFORE}`
+			)
+			notice.createEl('a', {
+				text: TLDRAW_OFFLINE_EXPORT_PROMPT_LINK,
+				href: TLDRAW_OFFLINE_EXPORT_URL,
+			})
+			notice.appendText(TLDRAW_OFFLINE_EXPORT_PROMPT_AFTER)
+			new Notice(notice)
 			return undefined
 		}
 

--- a/src/utils/file.ts
+++ b/src/utils/file.ts
@@ -1,5 +1,9 @@
-import { Platform, TFile } from 'obsidian'
+import { Notice, Platform, TFile } from 'obsidian'
 import TldrawPlugin from 'src/main'
+import {
+	TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE,
+	TLDRAW_OFFLINE_UNSUPPORTED_TITLE,
+} from 'src/obsidian/TldrawOfflineFileView'
 import { showSaveFileModal } from 'src/obsidian/modal/save-file-modal'
 import {
 	Editor,
@@ -8,6 +12,7 @@ import {
 	serializeTldrawJsonBlob,
 	useDefaultHelpers,
 } from 'tldraw'
+import { TLDRAW_OFFLINE_FILE_EXTENSION } from './constants'
 import { migrateTldrawFileDataIfNecessary } from './migrate/tl-data-to-tlstore'
 // import { shouldOverrideDocument } from "src/components/file-menu/shouldOverrideDocument";
 
@@ -103,12 +108,16 @@ export function importFileAction(
 		readonlyOk: true,
 		async onSelect(source) {
 			const tFile = await importTldrawFile(plugin)
+			if (!tFile) return
 			await plugin.openTldrFile(tFile, 'new-tab')
 		},
 	}
 }
 
-export async function importTldrawFile(plugin: TldrawPlugin, attachTo?: TFile) {
+export async function importTldrawFile(
+	plugin: TldrawPlugin,
+	attachTo?: TFile
+): Promise<TFile | undefined> {
 	if ('showOpenFilePicker' in window) {
 		const [file] = await window.showOpenFilePicker({
 			id: 'tldraw-open-file',
@@ -117,12 +126,19 @@ export async function importTldrawFile(plugin: TldrawPlugin, attachTo?: TFile) {
 				{
 					description: 'Tldraw Document',
 					accept: {
-						'text/tldr': ['.tldr'],
+						// tldraw offline files are selectable so that we can explain why we can't import
+						// them yet. Leaving them out would just grey them out with no explanation.
+						'text/tldr': ['.tldr', TLDRAW_OFFLINE_FILE_EXTENSION],
 					},
 				},
 			],
 			excludeAcceptAllOption: true,
 		})
+
+		if (file.name.endsWith(TLDRAW_OFFLINE_FILE_EXTENSION)) {
+			new Notice(`${TLDRAW_OFFLINE_UNSUPPORTED_TITLE}. ${TLDRAW_OFFLINE_UNSUPPORTED_MESSAGE}`)
+			return undefined
+		}
 
 		return plugin.createUntitledTldrFile({
 			attachTo,

--- a/src/utils/tldraw-offline-message.ts
+++ b/src/utils/tldraw-offline-message.ts
@@ -1,0 +1,24 @@
+const TLDRAW_OFFLINE_URL = 'https://offline.tldraw.com/'
+
+/** Anchors the "Export as .tldr" section of the tldraw offline user manual. */
+const TLDRAW_OFFLINE_EXPORT_URL =
+	'https://tldraw.notion.site/User-manual-tldraw-offline-39a3e4c324c080e7b2eacc5afd078e85#3aa3e4c324c080669967e2cc3ae2c789'
+
+/**
+ * Appends the explanation for why a `.tldraw` file can't be opened, and the way forward, into
+ * {@linkcode parent}.
+ *
+ * Built as nodes rather than returned as a string so that both the file view and the import notice
+ * can carry the links: Obsidian's `Notice` only renders them when given a fragment.
+ */
+export function appendTldrawOfflineMessage(parent: HTMLElement | DocumentFragment) {
+	const explanation = parent.createEl('p')
+	explanation.appendText('We’re working on support for files from ')
+	explanation.createEl('a', { text: 'tldraw offline', href: TLDRAW_OFFLINE_URL })
+	explanation.appendText('.')
+
+	const prompt = parent.createEl('p')
+	prompt.appendText('For now, you can ')
+	prompt.createEl('a', { text: 'export as a .tldr file', href: TLDRAW_OFFLINE_EXPORT_URL })
+	prompt.appendText(' to use it here.')
+}


### PR DESCRIPTION
People are saving files out of tldraw offline and trying to open them elsewhere. Those are `.tldraw` files — archives holding a zipped SQLite database and its assets, rather than the JSON a `.tldr` file holds — so nothing in this plugin can read one. Until support lands, this recognizes the extension and explains that.

Before this, a `.tldraw` file in the vault landed on Obsidian's generic "no view for this file type" screen, with nothing to say tldraw was involved.

This only detects the extension — it does no parsing.

The message links to tldraw offline itself and to the export instructions in its user manual, so it points somewhere rather than just saying no. Both are built as nodes by a shared helper: Obsidian's `Notice` only renders a link when given a fragment rather than a string, and the file view needs the same copy.

The new view extends `FileView` directly rather than `BaseTldrawFileView`, which reads the file as text and parses it as JSON; on an archive that just produces an opaque `Unable to parse TldrawFile.` The view type is deliberately kept out of `VIEW_TYPES`, since including it would let `updateViewMode` fall through to `setMarkdownView` and flip a binary file into the markdown editor.

Claiming the extension takes away Obsidian's own handling for unrecognized files, so the view offers "open in default app" — otherwise opening a `.tldraw` in the vault would leave the user with no route to a program that can actually read it.

Two things worth flagging in the diff:

- `importTldrawFile` now returns `undefined` instead of throwing when there's nothing to import. None of its three callers had a `try`/`catch`, so throwing would have surfaced as an unhandled rejection with no user feedback.
- The extension check is case-insensitive. File dialogs on macOS and Windows match their filters that way, so `Drawing.TLDRAW` is selectable and would otherwise have slipped through to the JSON parser.

Not covered: `![[drawing.tldraw]]` embeds inside a note still fall through to Obsidian's default handling, since `embedRegistry` only registers `tldr`.

## Test plan

1. Save a file from tldraw offline so you have a `.tldraw` file, and put it in a vault.
2. Click it in the file explorer — expect "Can't open .tldraw files yet" rather than Obsidian's unknown-file screen.
3. Use the "Open in default app" action in the tab bar, and the same item in the tab context menu.
4. Run "Import file as new document and open in a new tab" and pick the `.tldraw` file — expect a notice, and no unhandled error in the console.
5. Rename it to `.TLDRAW` and repeat step 4 — same notice.
6. Confirm `.tldr` files still open, import, and embed exactly as before.

