### PR TITLE
Generate release notes from the merged pull requests

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -86,12 +86,26 @@ jobs:
           git push origin "refs/tags/$tag"
           echo "✅ Tagged $(git rev-parse --short HEAD) as $tag"
 
+          # Notes are generated from the pull requests merged since the last full release. Reading
+          # them from the tag instead gives you whatever commit happened to be tagged, which since
+          # the tag is created here is just the previous PR's description.
+          notes_args="--generate-notes"
+          previous="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq .tag_name 2>/dev/null || true)"
+          if [ -n "$previous" ]; then
+            # /releases/latest skips prereleases and drafts, so this is the last version people
+            # actually got, which is the useful thing to list changes against.
+            notes_args="$notes_args --notes-start-tag $previous"
+            echo "ℹ️  Generating notes for changes since $previous"
+          else
+            echo "ℹ️  No previous release found; generating notes from the full history"
+          fi
+
           # Create empty draft release
           gh release create "$tag" \
             --title "$tag" \
-            --notes-from-tag \
             --draft \
             --verify-tag \
+            $notes_args \
             $prerelease_args
           
           if [ $? -ne 0 ]; then


### PR DESCRIPTION
Release notes came from the tagged commit, and since #215 the workflow creates that tag itself — so the notes ended up being whatever landed last. The alpha shipped carrying #215's own description, which had nothing to do with what was in the release.

This generates them instead, from the pull requests merged since the last full release.

The start tag comes from `repos/{repo}/releases/latest`, which skips prereleases and drafts. That matters here: without it, 1.30.0's notes would be computed against `1.30.0-alpha.1` and come out nearly empty, rather than listing everything since 1.29.0 — the version people are actually on.

Generated notes are a floor, not a ceiling. They list merged PRs by title, which is a reasonable default; a release worth describing still wants a hand-written top, via `gh release edit` or the GitHub UI.

## Test plan

Can't be exercised without publishing. Next release should open with a "What's Changed" list of the PRs merged since 1.29.0, rather than a copy of the previous PR's description.